### PR TITLE
modified viewer.R function at line 1577, change + to - for min.value

### DIFF
--- a/R/viewers.R
+++ b/R/viewers.R
@@ -1574,7 +1574,7 @@ phenoViewer <- function(Results,
         min.value <- min(c(data$value, data$lower.bound), na.rm = TRUE)
 
         max.value <- max.value + 0.1 * max.value
-        min.value <- min.value + 0.1 * min.value
+        min.value <- min.value - 0.1 * min.value
         
         if (show.mean == "both" || show.mean == "none") {
             color <- ifelse(is.null(assignments), "samples", "bc")


### PR DESCRIPTION
Can you double check this bug? This bug lead to break of  ribbon when using pheoViewer() function at some point because of min.value is not correct.